### PR TITLE
Fix two C syntax edge cases

### DIFF
--- a/R/get_src_messages.R
+++ b/R/get_src_messages.R
@@ -127,6 +127,9 @@ get_file_src_messages = function(file, translation_macro = "_") {
           ii = skip_white(contents_char, kk)
         } else if (contents_char[jj] == '"') {
           ii = jj
+        } else if (contents_char[jj] == "\\" && jj < nn && contents_char[jj+1L] == "\n") {
+          # line continuation, e.g. as seen in src/library/stats/src/optimize.c:686 as of r80365
+          ii = skip_white(contents_char, jj + 2L)
         } else {
           stop('Unexpected sequence -- a char array not followed by whitespace then any of [,)"] or a macro')
         }

--- a/R/get_src_messages.R
+++ b/R/get_src_messages.R
@@ -106,10 +106,8 @@ get_file_src_messages = function(file, translation_macro = "_") {
         }
         # add this completed array to our string
         string = paste0(string, substr(contents, ii+1L, jj-1L))
-        # jump past "
-        jj = jj + 1L
-        # now jump past any whitespace
-        while (jj <= nn && contents_char[jj] %chin% c(" ", "\n", "\r", "\t")) { jj = jj + 1L }
+        # jump past " and any subsequent whitespace
+        jj = skip_white(contents_char, jj + 1L)
         if (jj > nn) {
           stop("File terminated before translation array completed")
         }
@@ -126,7 +124,7 @@ get_file_src_messages = function(file, translation_macro = "_") {
           kk = jj + 1L
           while (grepl(C_IDENTIFIER_REST, contents_char[kk])) { kk = kk + 1L }
           string = paste0(string, "<", substr(contents, jj, kk-1L), ">")
-          ii = kk
+          ii = skip_white(contents_char, kk)
         } else if (contents_char[jj] == '"') {
           ii = jj
         } else {
@@ -182,6 +180,13 @@ preprocess = function(contents) {
     ii = ii + 1L
   }
   return(contents)
+}
+
+skip_white = function(chars, from_idx) {
+  jj = from_idx
+  nn = length(chars)
+  while (jj <= nn && chars[jj] %chin% c(" ", "\n", "\r", "\t")) { jj = jj + 1L }
+  return(jj)
 }
 
 # gleaned from iterating among WRE, src/include/Rinternals.h, src/include/R_ext/{Error.h,Print.h}

--- a/R/get_src_messages.R
+++ b/R/get_src_messages.R
@@ -5,6 +5,8 @@
 #   - mark c-format by looking for % ?, though note that this is note advised:
 #     https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files
 #     will the wrap-up call to update_pkg_po() handle this for us?
+#   - check that we're parsing \-continued char arrays correctly:
+#     https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#String-Constants
 get_src_messages = function(dir = ".", translation_macro = "_") {
   src_files = package_src_files(dir)
   names(src_files) = src_files
@@ -127,8 +129,8 @@ get_file_src_messages = function(file, translation_macro = "_") {
           ii = skip_white(contents_char, kk)
         } else if (contents_char[jj] == '"') {
           ii = jj
-        } else if (contents_char[jj] == "\\" && jj < nn && contents_char[jj+1L] == "\n") {
-          # line continuation, e.g. as seen in src/library/stats/src/optimize.c:686 as of r80365
+        } else if (contents_char[jj] == "\\" && jj < nn && contents_char[jj+1L] %chin% c("\n", "\r")) {
+          # line continuation, e.g. as seen in src/library/stats/src/optimize.c:686 as of r80365.
           ii = skip_white(contents_char, jj + 2L)
         } else {
           stop('Unexpected sequence -- a char array not followed by whitespace then any of [,)"] or a macro')

--- a/tests/testthat/test_packages/r_src_c/src/bar.c
+++ b/tests/testthat/test_packages/r_src_c/src/bar.c
@@ -11,8 +11,8 @@ char *stardust(SEXP z);
 
 // include this comment here to test comment skipping works
 static void glam(SEXP x) {
-  // test platform-robust format specification as done here
-  Rprintf(_("an translated templated string: %"PRId64"\n"), 10000LL);
+  // test platform-robust format specification as done here; add spacing on either side for #44
+  Rprintf(_("an translated templated string: %"  PRId64  "\n"), 10000LL);
 }
 
 char *stardust(SEXP z) {
@@ -21,7 +21,8 @@ char *stardust(SEXP z) {
 
 /* Add a call here to make sure comment skipping works: Rprintf(_("hi")); */
 static void ziggy(SEXP y, SEXP z) {
-  // nested parentheses before we reach the end of the call
-  warning(_("a translated warning: %s\n"), stardust(z));
+  // nested parentheses before we reach the end of the call; use the line-continuation \ for #44
+  warning(_("a translated "\
+"warning: %s\n"), stardust(z));
   return;
 }


### PR DESCRIPTION
Closes #47

 1. Macro format identifiers need not be followed immediately by `"`: https://github.com/wch/r-source/blob/1a362d092e129da916964df66a6be0ad2bd3acd0/src/library/stats/src/fourier.c#L298
 2. `\` is a valid "whitespace" character when used for line continuation: https://github.com/wch/r-source/blob/1a362d092e129da916964df66a6be0ad2bd3acd0/src/library/stats/src/optimize.c#L686

Need to add tests for these