### PR TITLE
Exclude empty msgid from write_po_files

### DIFF
--- a/R/get_r_messages.R
+++ b/R/get_r_messages.R
@@ -50,11 +50,6 @@ get_r_messages <- function (dir) {
     idcol = 'type'
   )
 
-  # drop empty strings. we could do this earlier but it's messier.
-  #   TODO: can we just strip these STR_CONST from expr_data with no
-  #         other repercussions?
-  msg = msg[type == 'plural' | nzchar(msgid)]
-
   if (!nrow(msg)) return(r_message_schema())
 
   msg_files = unique(msg$file)

--- a/R/get_src_messages.R
+++ b/R/get_src_messages.R
@@ -161,8 +161,6 @@ get_file_src_messages = function(file, translation_macro = "_") {
   }
 
   src_messages = rbindlist(lapply(seq_along(msg_match), get_call_message))
-  # prune empty messages (#83)
-  src_messages = src_messages[nzchar(src_messages)]
   src_messages[ , "line_number" := msg_line]
   src_messages[ , "is_marked_for_translation" := is_translated]
   src_messages[]

--- a/R/get_src_messages.R
+++ b/R/get_src_messages.R
@@ -81,7 +81,7 @@ get_file_src_messages = function(file, translation_macro = "_") {
   get_call_message = function(msg_i) {
     ii = msg_start[msg_i]
 
-    string = character(1L)
+    string = ""
     # regex landed us after ( in untranslated calls and after (_( in translated ones
     stack_size = if (is_translated[msg_i]) 2L else 1L
     if (contents_char[ii] == '"') {
@@ -161,6 +161,8 @@ get_file_src_messages = function(file, translation_macro = "_") {
   }
 
   src_messages = rbindlist(lapply(seq_along(msg_match), get_call_message))
+  # prune empty messages (#83)
+  src_messages = src_messages[nzchar(src_messages)]
   src_messages[ , "line_number" := msg_line]
   src_messages[ , "is_marked_for_translation" := is_translated]
   src_messages[]

--- a/R/write_po_file.R
+++ b/R/write_po_file.R
@@ -18,7 +18,9 @@ write_po_files <- function(message_data, po_dir, params, template = FALSE) {
   # also considered:
   #   * rbind() each {R,src}x{singular,plural} combination together, but was getting quite lengthy/verbose/repetitive.
   #   * split(,by='message_source,type') but missing levels (e.g., src.plural) need to be handled separately
-  po_data = message_data[(is_marked_for_translation)]
+  # also drop empty strings. these are kept until now in case they are needed for diagnostics, but can't be
+  #   written to the .po/.pot files (msgid "" is reserved for the metadata header). Related: #83.
+  po_data = message_data[is_marked_for_translation & (type == "plural" | nzchar(msgid))]
 
   if (template) {
     r_file <- sprintf("R-%s.pot", params$package)

--- a/tests/testthat/test_packages/unusual_msg/src/msg.c
+++ b/tests/testthat/test_packages/unusual_msg/src/msg.c
@@ -19,5 +19,8 @@ void hello_world(SEXP x) {
     "01234567890123456789.01234567890123456789"
     "01234567890123456789.01234567890123456789"
   ));
+  // An array as a variable is passed, see #83
+  char * msg = "an error occurred";
+  error(_(msg));
   return;
 }


### PR DESCRIPTION
Closes #83

Restore empty messages found in R as well -- that way they can be shown as part of diagnostics, potentially (ditto those found in src).