### PR TITLE
Fix skip_paren for files with opening paren as char ('(')

### DIFF
--- a/R/get_src_messages.R
+++ b/R/get_src_messages.R
@@ -257,7 +257,7 @@ skip_parens = function(ii, chars, array_boundaries, file, newlines_loc) {
       ')' = { stack_size = stack_size - 1L; jj = jj + 1L },
       '"' = { jj = array_boundaries[.(jj), array_end] + 1L },
       # don't get mixed up by '(' or ')', #112
-      "'" = { jj = jj + 2L },
+      "'" = { jj = jj + 3L },
       { jj = jj + 1L }
     )
   }

--- a/R/get_src_messages.R
+++ b/R/get_src_messages.R
@@ -256,6 +256,8 @@ skip_parens = function(ii, chars, array_boundaries, file, newlines_loc) {
       '(' = { stack_size = stack_size + 1L; jj = jj + 1L },
       ')' = { stack_size = stack_size - 1L; jj = jj + 1L },
       '"' = { jj = array_boundaries[.(jj), array_end] + 1L },
+      # don't get mixed up by '(' or ')', #112
+      "'" = { jj = jj + 2L },
       { jj = jj + 1L }
     )
   }

--- a/tests/testthat/test_packages/unusual_msg/src/msg.c
+++ b/tests/testthat/test_packages/unusual_msg/src/msg.c
@@ -27,8 +27,10 @@ void hello_world(SEXP x) {
   char * msg = "an error occurred";
   error(_(msg));
 
-  // Not thrown off by a char literal "
+  // Not thrown off by a char literal ", (, or )
   *msg = '"';
+  *msg = '(';
+  *msg = ')';
 
   // repeat a bunch of times to test the strwrap behavior of file markers
   Rprintf(_("an translated templated string: %"  PRId64  "\n"), 10000LL);

--- a/tests/testthat/test_packages/unusual_msg/src/msg.c
+++ b/tests/testthat/test_packages/unusual_msg/src/msg.c
@@ -27,10 +27,12 @@ void hello_world(SEXP x) {
   char * msg = "an error occurred";
   error(_(msg));
 
-  // Not thrown off by a char literal ", (, or )
+  // Not thrown off by a char literal ", (, or ) (right-paren comes first to keep imbalance)
   *msg = '"';
-  *msg = '(';
   *msg = ')';
+  *msg = '(';
+  // also make sure the char array jump is exactly right (if we over-jump here we won't find the right-parent)
+  foo(msg, '.');
 
   // repeat a bunch of times to test the strwrap behavior of file markers
   Rprintf(_("an translated templated string: %"  PRId64  "\n"), 10000LL);


### PR DESCRIPTION
Closes #112 