### PR TITLE
Faster implementation of get_src_messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### v0.2.1 (in development)
 
  * Skip tests on machines where `gettext` is unavailable, #187
+ * Faster parsing of src messages (e.g. `get_message_data()` for the `base` package reduced from 14 to 7 seconds), #119
 
 ### v0.2.0 (June 2202)
 

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -22,7 +22,7 @@ test_that("check_cracked_messages works", {
 
   expect_equal(
     check_cracked_messages(message_data),
-    data.table(
+    data.table::data.table(
       call = c('message("farewell", "sir")', 'warning("found ", nn, " problems")'),
       file = 'foo.R',
       line_number = c(2L, 4L),
@@ -52,7 +52,7 @@ test_that("check_untranslated_cat works", {
 
   expect_equal(
     check_untranslated_cat(message_data),
-    data.table(
+    data.table::data.table(
       call = c('cat("hello")', 'cat("farewell", "sir")'),
       file = 'foo.R',
       line_number = 1:2,
@@ -105,7 +105,7 @@ test_that("check_untranslated_src works", {
 
   expect_equal(
     check_untranslated_src(message_data),
-    data.table(
+    data.table::data.table(
       call = c('Rprintf("Found an issue", s)'),
       file = 'bar.c',
       line_number = 1L,


### PR DESCRIPTION
`get_message_data("~/svn/R-devel/src/library/base")` reduced from circa 14 seconds to circa 7.

Not a life-changing improvement, but noticeable nonetheless.

Tested it works on all of base.

Closes #119 for now