### PR TITLE
usethis::use_coverage()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^\.Rproj\.user$
 
 ^\.sandbox$
+^codecov\.yml$

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
This is the standard `codecov.yml` that we use; but don't ask me to explain because I've forgotten why we chose these values.