### PR TITLE
Reduce readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,162 +2,40 @@
 
 ## Overview
 
-R users are a global community. From Xiamen to Santiago, Addis Ababa to Tbilisi, Ogallala to Adelaide, R users are legion and their native languages are as well.
-
-If the target audience of your package extends beyond the English-speaking world, or if you want to make the user experience for the non-native English speakers using your tools, you can consider internationalizing your package by translating its user-facing communications (verbose messages, warnings, errors, etc.).
-
-Unfortunately, to do so has some tedious aspects, namely, learning the gettext system of `.po` files, `.pot` templates, and `.mo` binaries -- another syntax rife with quirks and idiosyncrasies.
-
-`potools` is designed to minimize the friction to translating your package by abstracting away as many details of the `.po` system of translations as possible.
-
-The core function of `potools`, `translate_package`, is a one-stop-shop for interactively setting your package up for translation and providing those translations, all without ever having to touch a `.po` file yourself.
-
-`potools` is a UTF-8 package -- all `.po` and `.pot` files it produces will be treated as UTF-8.
+R users are a global community. From Xiamen to Santiago, Addis Ababa to Tbilisi, Ogallala to Adelaide, R users are legion and speak many different languages. To serve these diverse communities, R includes built-in tools based on the [GNU gettext system](https://www.gnu.org/software/gettext/) that make it possible to translate user-facing communications like messages, warnings, and errors. Unfortunately, this system uses new file types (`.pot` templates, `.po` files, and `.mo` binaries) that come with their own quirks and idiosyncrasies. The goal of potools is make it as easy as possible to translate your package by abstracting away as many details of the gettext systemas possible.
 
 The potool logo features a [potoo](https://en.wikipedia.org/wiki/Potoo) and was designed by [Allison Horst](https://www.allisonhorst.com).
 
-### Translating your package interactively with `translate_package()`
-
-The primary feature of `potools` is the `translate_package()` function, which is designed to be your first & only stop for typical experience internationalizing a package
-
-#### As a developer -- generating a .pot template
-
-A .pot template can be used by translators to produce translations; just running `translate_package()` on your package's source will produce this file (or files, if your package has both R and C/C++ messages to translated), e.g.
-
-```
-# run from the directory into which potools is cloned, i.e., 'potools' here is a file path
-translate_package('potools')
-```
-
-#### As a translator -- generating a .po translation & .mo translation binary
-
-To further add translations in your desired language, include the target language in the `translate_package()` call.
-
-Running the following will launch an interactive dialog prompting for translations message-by-message:
-
-```
-# es.po & es.mo Spanish translation files will be produced
-translate_package('potools', 'es')
-```
-
-### Customized translators
-
-`base` R provides several functions for messaging that are natively equipped for translation (they all have a `domain` argument): `stop()`, `warning()`, `message()`, `gettext()`, `gettextf()`, `ngettext()`, and `packageStartupMessage()`.
-
-While handy, some developers may prefer to write their own functions, or to write wrappers of the provided functions that provide some enhanced functionality (e.g., templating or automatic wrapping). In this case, the default R tooling for translation (`xgettext()`, `xngettext()` `xgettext2pot()`, `update_pkg_po()` from `tools`) will not work, but `potools::translate_package()` and its workhorse `potools::get_message_data()` provide an interface to continue building translations for your workflow.
-
-Suppose you wrote a function `stopf()` that is a wrapper of `stop(gettextf())` used to build templated error messages in R, which makes translation easier for translators (see below), e.g.:
-
-
-```
-stopf = function(fmt, ..., domain = NULL) {
-  stop(gettextf(fmt, ...), domain = domain, call. = FALSE)
-}
-```
-
-Note that `potools` itself uses just such a wrapper internally to build error messages! To extract strings from calls in your package to `stopf()` and mark them for translation, use the argument `custom_translation_functions`:
-
-```
-get_message_data(
-  '/path/to/my_package',
-  custom_translation_functions = list(R = 'stopf:fmt|1')
-)
-```
-
-This invocation tells `get_message_data()` to look for strings in the `fmt` argument in calls to `stopf()`. `1` indicates that `fmt` is the first argument.
-
-More specifications are possible, including marking custom calls in C/C++; see `?translate_package` for a full explanation.
-
-Note that this is only good for _marking_ such strings for translation -- for them to actually be translated during code execution, your custom function will ultimately have to be pass the strings to `gettext()` or `gettextf()` (as done in the `stopf()` example). Without doing so, the string will always just appear in English.
-
-### Diagnostics
-
-`translate_package` also runs some diagnostics that can help make your package more translation-ready (see below).
-
-#### Cracked messages
-
-A cracked message is one like:
-
-```r
-stop("There are ", n, " good things and ", m, " bad things.")
-```
-
-In its current state, translators will be asked to translate three messages independently:
-
- - "There are"
- - "good things and"
- - "bad things."
- 
-The message has been cracked; it might not be possible to translate a string as generic as "There are" into many languages -- context is key!
-
-To keep the context, the error message should instead be build with `gettextf` like so:
-
-```r
-stop(domain=NA, gettextf("There are %d good things and %d bad things."))
-```
-
-Now there is only one string to translate! Note that this also allows the translator to change the word
-order as they see fit -- for example, in Japanese, the grammatical order usually puts the verb last (where
-in English it usually comes right after the subject).
-
-`translate_package` detects such cracked messages and suggests a `gettextf`-based approach to fix them.
-
-#### Untranslated R messages produced by `cat()`
-
-Only strings which are passed to certain `base` functions are eligible for translation, namely `stop`, `warning`, `message`, `packageStartupMessage`, `gettext`, `gettextf`, and `ngettext` (all of which have a `domain` argument that is key for translation).
-
-However, it is common to also produce some user-facing messages using `cat` -- if your package does so, it must first
-use `gettext` or `gettextf` to translate the message before sending it to the user with `cat`.
-
-`translate_package` detects strings produced with `cat` and suggests a `gettext`- or `gettextf`-based fix.
-
-#### Untranslated C/C++ messages
-
-This diagnostic detects any literal `char` arrays provided to common messaging functions in C/C++, namely `ngettext()`, `Rprintf()`, `REprintf()`, `Rvprintf()`, `REvprintf()`, `R_ShowMessage()`, `R_Suicide()`, `warning()`, `Rf_warning()`, `error()`, `Rf_error()`, `dgettext()`, and `snprintf()`. To actually translate these strings, pass them through the translation macro `_`.
-
-NB: Translation in C/C++ requires some additional `#include`s and declarations, including defining the `_` macro. See the Internationalization section of Writing R Extensions for details.
-
 ## Installation
 
-`potools` is on CRAN as of v0.2.0.
+Start by installing the released version potools from CRAN:
 
-You can also install the latest development version from GitHub. The easiest way to do so:
+```R
+install.packages("potools")
+```
 
-```r
+Or the development version from GitHub:
+
+```R
 # install.packages("remotes")
 remotes::install_github("MichaelChirico/potools")
 ```
 
-## Tips & Tricks for Translation
+You'll also need to install gettext, the GNU command line toolkit that powers potools. Installation depends on your operating system:
 
-### Searchable error messages
+* On Windows, gettext is bundled with [Rtools](https://cran.r-project.org/bin/windows/Rtools/), so if you're developing packages you probably already have it.
 
-One observation about offering translated messages is that non-English messages are harder to google. A few suggestions:
- 
-+ You can give error messages a unique identifier (e.g. numbering). This may be harder to do for "established" packages since adding identifiers might be a breaking change.
-+ End users can switch to an English locale mid-session by running `Sys.setenv(LANGUAGE = 'en')` -- error messages will be produced in English until they set `LANGUAGE` again.
-+ You could write a custom error wrapper that produces the error both in English and as a translation.
-     
-### Translating technical terms
+* On Mac, it's easiest to install with [brew](https://brew.sh): `brew install gettext`
 
-Technical terms are par for the course in R packages; showing users similar terms for the same concept might lead to needless confusion. R recommends using the [ISI Multilingual Glossary of Statistical Terms](https://www.isi-web.org/publications/glossary-of-statistical-terms) to help overcome this issue.
+* On Linux, it's usually already installed; otherwise you'll need to install `gettext` with your distro's standard tool.
 
-### Picking a domain for diasporic languages
+## Workflow
 
-What domain should you use when translating Spanish? There's `es_AR`, `es_BO`, `es_CL`, `es_DO`, `es_HN`, ... do I
-really need to provide a separate file for my Nicaraguan (`es_NI`) users?
+There are two core workflows provided by potools:
 
-No, but you could. Typically, you are best off creating one set of translations under the language's general
-domain (here, `es`). Once translations exist for `es`, users in all of the more specific locales will see the
-messages for `es` whenever they exist. If you really do want to provide more regionally-specific error messages
-(awesome!), you can either (1) create a whole new set of translations for each region or (2) write translations
-_only for the region-specific messages_. The latter is how R handles messages that differ on British/American
-spelling, for example.
+* `translate_package()` is a one-stop-shop for interactively setting your package and providing  translations, as described in `?translate_package`.
 
-Say a user is running in `es_GT` and triggers an error. R will first look for a translation into `es_GT`; if
-none is defined, it will look for a translation into `es`. If none is defined again, it will finally fall
-back to the package's default language (i.e., whatever language is written in the source code, usually English).
-
+* `po_extract()`, `po_create()`, `po_update()`, and `po_compile()` let you perform the individual steps of `translate_package()` as described in `vignette("developers")` and `vignette("translators")`.
 
 ## Alternative software
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-R users are a global community. From Xiamen to Santiago, Addis Ababa to Tbilisi, Ogallala to Adelaide, R users are legion and speak many different languages. To serve these diverse communities, R includes built-in tools based on the [GNU gettext system](https://www.gnu.org/software/gettext/) that make it possible to translate user-facing communications like messages, warnings, and errors. Unfortunately, this system uses new file types (`.pot` templates, `.po` files, and `.mo` binaries) that come with their own quirks and idiosyncrasies. The goal of potools is make it as easy as possible to translate your package by abstracting away as many details of the gettext systemas possible.
+R users are a global community. From Xiamen to Santiago, Addis Ababa to Tbilisi, Ogallala to Adelaide, R users are legion and speak many different languages. To serve these diverse communities, R includes built-in tools based on the [GNU gettext system](https://www.gnu.org/software/gettext/) that make it possible to translate user-facing communications like messages, warnings, and errors. Unfortunately, this system uses new file types (`.pot` templates, `.po` files, and `.mo` binaries) that come with their own quirks and idiosyncrasies. The goal of potools is make it as easy as possible to translate your package by abstracting away as many details of the gettext system as possible.
 
 The potool logo features a [potoo](https://en.wikipedia.org/wiki/Potoo) and was designed by [Allison Horst](https://www.allisonhorst.com).
 

--- a/man/translate_package.Rd
+++ b/man/translate_package.Rd
@@ -21,8 +21,14 @@ translate_package(
 \item{dir}{Character, default the present directory; a directory in which an
 R package is stored.}
 
-\item{languages}{Character vector; locale codes to which to translate. See
-Details.}
+\item{languages}{Character vector; locale codes to which to translate.
+Must be a valid language accepted by gettext. This almost always takes
+the form of (1) an ISO 639 2-letter language code; or (2) \code{ll_CC}, where
+\code{ll} is an ISO 639 2-letter language code and \code{CC} is an ISO 3166 2-letter
+country code e.g. \code{es} for Spanish, \code{es_AR} for Argentinian Spanish, \code{ro}
+for Romanian, etc. See \code{\link[base:locales]{base::Sys.getlocale()}} for some helpful tips
+about how to tell which locales are currently available on your machine, and
+see the References below for some web resources listing more locales.}
 
 \item{diagnostics}{A \code{list} of diagnostic functions to be run on the
 package's message data. See Details.}
@@ -58,25 +64,29 @@ This function handles the "grunt work" of building and updating translation
 libraries. In addition to providing a friendly interface for supplying
 translations, some internal logic is built to help make your package more
 translation-friendly.
+
+To get started, the package developer should run \code{translate_package()} on
+your package's source to produce a template \code{.pot} file (or files, if your
+package has both R and C/C++ messages to translated), e.g.
+
+To add translations in your desired language, include the target language:
+in the \code{translate_package(languages = "es")} call.
 }
-\details{
-To do so, it builds on low-level command line tools from \code{gettext}. See
-Details.
+\section{Phases}{
 
-\code{translate_package} goes through roughly three "phases" of translation.
-
-Phase one is setup -- \code{dir} is checked for existing translations
+\code{translate_package()} goes through roughly three "phases" of translation.
+\enumerate{
+\item Setup -- \code{dir} is checked for existing translations
 (toggling between "update" and "new" modes), and R files are parsed and
 combed for user-facing messages.
-
-Phase two is for diagnostics; see the Diagnostics section below. Any
+\item Diagnostics:  see the Diagnostics section below. Any
 diagnostic detecting "unhealthy" messages will result in a yes/no prompt to
 exit translation to address the issues before continuing.
-
-Phase three is translation. All of the messages found in phase one are
-iterated over -- the user is shown a message in English and prompted for the
-translation in the target language. This process is repeated for each domain
+\item Translation. All of the messages found in phase one are iterated over --
+the user is shown a message in English and prompted for the translation
+in the target language. This process is repeated for each domain
 in \code{languages}.
+}
 
 An attempt is made to provide hints for some translations that require
 special care (e.g. that have escape sequences or use templates). For
@@ -102,16 +112,45 @@ base R and the default packages (\code{tools}, \code{utils}, \code{stats},
 etc.) as smooth as possible, set the \code{use_base_rules} argument to
 \code{TRUE} and your resulting \file{.po}/\file{.pot}/\file{.mo} file will
 match base's.
+}
 
-\strong{Custom translation functions:}
+\section{Custom translation functions}{
 
-Some package developers may want to write their own messaging interface, or
-to use wrappers around the base interface (i.e., \code{stop},
-\code{warning}, \code{message}, and a few others) which won't be detected by
-default (e.g. with \code{\link[tools:update_pkg_po]{tools::update_pkg_po()}}).
 
-In such cases, use the \code{custom_translation_functions} argument, whose
-interface is inspired by the \code{--keyword} argument to the
+\code{base} R provides several functions for messaging that are natively equipped
+for translation (they all have a \code{domain} argument): \code{stop()}, \code{warning()},
+\code{message()}, \code{gettext()}, \code{gettextf()}, \code{ngettext()}, and
+\code{packageStartupMessage()}.
+
+While handy, some developers may prefer to write their own functions, or to
+write wrappers of the provided functions that provide some enhanced
+functionality (e.g., templating or automatic wrapping). In this case,
+the default R tooling for translation (\code{xgettext()}, \code{xngettext()}
+\code{xgettext2pot()}, \code{update_pkg_po()} from \code{tools}) will not work, but
+\code{translate_package()} and its workhorse \code{get_message_data()} provide an
+interface to continue building  translations for your workflow.
+
+Suppose you wrote a function \code{stopf()} that is a wrapper of
+\code{stop(gettextf())} used to build templated error messages in R, which makes
+translation easier for translators (see below), e.g.:\if{html}{\out{<div class="sourceCode R">}}\preformatted{stopf = function(fmt, ..., domain = NULL) \{
+  stop(gettextf(fmt, ...), domain = domain, call. = FALSE)
+\}
+}\if{html}{\out{</div>}}
+
+Note that \code{potools} itself uses just such a wrapper internally to build
+error messages! To extract strings from calls in your package to \code{stopf()}
+and mark them for translation, use the argument
+\code{custom_translation_functions}:\if{html}{\out{<div class="sourceCode R">}}\preformatted{get_message_data(
+  '/path/to/my_package',
+  custom_translation_functions = list(R = 'stopf:fmt|1')
+)
+}\if{html}{\out{</div>}}
+
+This invocation tells \code{get_message_data()} to look for strings in the
+\code{fmt} argument in calls to \code{stopf()}. \code{1} indicates that \code{fmt} is the
+first argument.
+
+This interface is inspired by the \code{--keyword} argument to the
 \code{xgettext} command-line tool. This argument consists of a list with two
 components, \code{R} and \code{src} (either can be excluded), owing to
 differences between R and C/C++. Both components, if present, should consist
@@ -119,21 +158,21 @@ of a character vector.
 
 For R, there are two types of input: one for named arguments, the other for
 unnamed arguments.
-
-Entries for named arguments will look like \code{"fname:arg|num"} (singular
+\itemize{
+\item Entries for \strong{named} arguments will look like \code{"fname:arg|num"} (singular
 string) or \code{"fname:arg1|num1,arg2|num2"} (plural string). \code{fname}
 gives the name of the function/call to be extracted from the R source,
 \code{arg}/\code{arg1}/\code{arg2} specify the name of the argument to
 \code{fname} from which strings should be extracted, and
 \code{num}/\code{num1}/\code{num2} specify the \emph{order} of the named
 argument within the signature of \code{fname}.
-
-Entries for unnamed arguments will look like
+\item Entries for \strong{unnamed} arguments will look like
 \code{"fname:...\\xarg1,...,xargn"}, i.e., \code{fname}, followed by
 \code{:}, followed by \code{...} (three dots), followed by a backslash
 (\verb{\\}), followed by a comma-separated list of argument names. All
 strings within calls to \code{fname} \emph{except} those supplied to the
 arguments named among \code{xarg1}, ..., \code{xargn} will be extracted.
+}
 
 To clarify, consider the how we would (redundantly) specify
 \code{custom_translation_functions} for some of the default messagers,
@@ -153,8 +192,71 @@ rather, to expand the set of calls which are searched for potentially
 \emph{untranslated} arrays (i.e., arrays passed to the specified calls that
 are not explicitly marked for translation). These can then be reported in
 the \code{\link[=check_untranslated_src]{check_untranslated_src()}} diagnostic, for example.
+}
 
-\strong{Diagnostics:}
+\section{Diagnostics}{
+
+\subsection{Cracked messages}{
+
+A cracked message is one like:\if{html}{\out{<div class="sourceCode r">}}\preformatted{stop("There are ", n, " good things and ", m, " bad things.")
+}\if{html}{\out{</div>}}
+
+In its current state, translators will be asked to translate three messages
+independently:
+\itemize{
+\item "There are"
+\item "good things and"
+\item "bad things."
+}
+
+The message has been cracked; it might not be possible to translate a string
+as generic as "There are" into many languages -- context is key!
+
+To keep the context, the error message should instead be build with
+\code{gettextf} like so:\if{html}{\out{<div class="sourceCode r">}}\preformatted{stop(domain=NA, gettextf("There are \%d good things and \%d bad things."))
+}\if{html}{\out{</div>}}
+
+Now there is only one string to translate! Note that this also allows the
+translator to change the word order as they see fit -- for example, in
+Japanese, the grammatical order usually puts the verb last (where in
+English it usually comes right after the subject).
+
+\code{translate_package} detects such cracked messages and suggests a
+\code{gettextf}-based approach to fix them.
+}
+
+\subsection{Untranslated R messages produced by \code{cat()}}{
+
+Only strings which are passed to certain \code{base} functions are eligible for
+translation, namely \code{stop}, \code{warning}, \code{message}, \code{packageStartupMessage},
+\code{gettext}, \code{gettextf}, and \code{ngettext} (all of which have a \code{domain} argument
+that is key for translation).
+
+However, it is common to also produce some user-facing messages using
+\code{cat} -- if your package does so, it must first use \code{gettext} or \code{gettextf}
+to translate the message before sending it to the user with \code{cat}.
+
+\code{translate_package} detects strings produced with \code{cat} and suggests a
+\code{gettext}- or \code{gettextf}-based fix.
+}
+
+\subsection{Untranslated C/C++ messages}{
+
+This diagnostic detects any literal \code{char} arrays provided to common
+messaging functions in C/C++, namely \code{ngettext()}, \code{Rprintf()}, \code{REprintf()},
+\code{Rvprintf()}, \code{REvprintf()}, \code{R_ShowMessage()}, \code{R_Suicide()}, \code{warning()},
+\code{Rf_warning()}, \code{error()}, \code{Rf_error()}, \code{dgettext()}, and \code{snprintf()}.
+To actually translate these strings, pass them through the translation
+macro \verb{_}.
+
+NB: Translation in C/C++ requires some additional \verb{#include}s and
+declarations, including defining the \verb{_} macro.
+See the Internationalization section of Writing R Extensions for details.
+}
+}
+
+\section{Custom diagnostics}{
+
 
 A diagnostic is a function which takes as input a \code{data.table}
 summarizing the translatable strings in a package (e.g. as generated by
@@ -179,41 +281,8 @@ The output diagnostic result has the following schema:
 See \code{\link[=check_cracked_messages]{check_cracked_messages()}},
 \code{\link[=check_untranslated_cat]{check_untranslated_cat()}}, and
 \code{\link[=check_untranslated_src]{check_untranslated_src()}} for examples of diagnostics.
-
-\strong{Domains:}
-
-The input to \code{languages} conform to the valid languages accepted by
-gettext. This almost always takes the form of (1) an ISO 639 2-letter
-language code; or (2) \code{ll_CC}, where \code{ll} is an ISO 639 2-letter
-language code and \code{CC} is an ISO 3166 2-letter country code e.g.
-\code{es} for Spanish, \code{es_AR} for Argentinian Spanish, \code{ro} for
-Romanian, etc. See \code{\link[base:locales]{base::Sys.getlocale()}} for some helpful tips
-about how to tell which locales are currently available on your machine, and
-see the References below for some web resources listing more locales.
-
-Note also the advice given in the R Installation and Administration manual
-(also cited below) -- if you are writing Spanish translations, a typical
-package should use \code{language = "es"} to generate Spanish translations
-for \emph{all} Spanish domains. If you want to add more regional flair to
-your messaging, you can do so through supplemental \code{.po} files. For
-example, you can add some Argentinian messages to \code{es_AR}; users
-running R in the \code{es_AR} locale will see messages specifically written
-for \code{es_AR} first; absent that, the \code{es} message will be shown;
-and absent that, the default message (i.e., in the language written in the
-source code, usually English).
-
-Chinese is a slightly different case -- typically, the \code{zh_CN} domain
-is used to write with simplified characters while \code{zh_TW} is used for
-traditional characters. In principal you could leverage \code{zh_TW} for
-Taiwanisms and \code{zh_HK} for Hongkieisms.
-
-Currently, translation is limited to the same set of domains as is available
-for base R: Danish, German, English, British English, Spanish, Farsi,
-French, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portugese,
-Russian, Turkish, Mainland Chinese, and Taiwanese Chinese.
-
-This list can be expanded; please file an Issue request on GitHub.
 }
+
 \examples{
 
 pkg <- system.file('pkg', package = 'potools')

--- a/vignettes/developers.Rmd
+++ b/vignettes/developers.Rmd
@@ -273,7 +273,7 @@ Generally, you want to help the translator spend as much time as possible helpin
 It's worth noting that that non-English messages are often harder to Google because few non-English languages have a significant presence on StackOverflow.
 A few suggestions:
 
--   You can give error messages a unique identifier (e.g. numbering). This may be harder to do for "established" packages since adding identifiers might be a breaking change.
+-   You can give error messages a unique identifier (e.g. numbering). This may be harder to do for "established" packages since adding identifiers might be a breaking change. It could also be a headache to keep track of which numbers have been taken, e.g. in a context of concurrent PRs incrementing the error numbering in parallel.
 -   End users can switch to an English locale mid-session by running `Sys.setenv(LANGUAGE = 'en')`: error messages will be produced in English until they set `LANGUAGE` again.
 -   You could write a custom error wrapper that produces the error both in English and as a translation.
 

--- a/vignettes/developers.Rmd
+++ b/vignettes/developers.Rmd
@@ -268,6 +268,15 @@ paste0("<a href='/index.html'>", tr_("Home page"), "</a>")
 
 Generally, you want to help the translator spend as much time as possible helping you out.
 
+## Googling
+
+It's worth noting that that non-English messages are often harder to Google because few non-English languages have a significant presence on StackOverflow.
+A few suggestions:
+
+-   You can give error messages a unique identifier (e.g. numbering). This may be harder to do for "established" packages since adding identifiers might be a breaking change.
+-   End users can switch to an English locale mid-session by running `Sys.setenv(LANGUAGE = 'en')`: error messages will be produced in English until they set `LANGUAGE` again.
+-   You could write a custom error wrapper that produces the error both in English and as a translation.
+
 ### Plurals
 
 In English, most nouns have different forms for one item (the singular) or more than one item (the plural, also used for zero items).

--- a/vignettes/translators.Rmd
+++ b/vignettes/translators.Rmd
@@ -93,6 +93,32 @@ If there's not quite enough context to figure out the best translation you can e
 
 Next we'll go through the details of a few message variations you might come across, show you how to try out your work, and then finish up by discussing a few extra details that arise when updating the translations for a package, rather than starting from scratch.
 
+### Picking a domain for diasporic languages
+
+What domain should you use when translating Spanish?
+There's `es_AR`, `es_BO`, `es_CL`, `es_DO`, `es_HN`, ... Do you really need to provide a separate translation for Nicaraguan (`es_NI`) users?
+No, but you could.
+
+Typically, you are best off creating one set of translations under the language's general domain (here, `es`).
+Once translations exist for `es`, users in all of the more specific locales will see the messages for `es` whenever they exist.
+If you really do want to provide more regionally-specific error messages (awesome!), you can either (1) create a whole new set of translations for each region or (2) write translations *only for the region-specific messages*.
+The latter is how R handles messages that differ on British/American spelling, for example.
+
+Say a user is running in `es_GT` and triggers an error.
+R will first look for a translation into `es_GT`; if none is defined, it will look for a translation into `es`.
+If none is defined again, it will finally fall back to the package's default language (i.e., whatever language is written in the source code, usually English).
+
+Note also the advice given in the R Installation and Administration manual (also cited below) -- if you are writing Spanish translations, a typical package should use `language = "es"` to generate Spanish translations for *all* Spanish domains.
+If you want to add more regional flair to your messaging, you can do so through supplemental `.po` files.
+For example, you can add some Argentinian messages to `es_AR`; users running R in the `es_AR` locale will see messages specifically written for `es_AR` first; absent that, the `es` message will be shown; and absent that, the default message (i.e., in the language written in the source code, usually English).
+
+Chinese is a slightly different case -- typically, the `zh_CN` domain is used to write with simplified characters while `zh_TW` is used for traditional characters.
+In principal you could leverage `zh_TW` for Taiwanisms and `zh_HK` for Hongkieisms.
+
+Currently, translation is limited to the same set of domains as is available for base R: Danish, German, English, British English, Spanish, Farsi, French, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portugese, Russian, Turkish, Mainland Chinese, and Taiwanese Chinese.
+
+This list can be expanded; please file an Issue request on GitHub.
+
 ## Message variations
 
 The following sections describe four important message variations:
@@ -194,6 +220,11 @@ Slovenian has four forms (1, 2, 3-4, everything else) so gets four entries:
 
 The rules for converting the number to the `msgid` index are expressed using C-code and can be found at the top of the `.po` file (look for "plural-forms").
 It's a little tricky to go from the C code to a human description of the cases, but if you're a native speaker you're hopefully already familiar with the basic breakdown.
+
+## Other issues
+
+Technical terms are par for the course in R packages; showing users similar terms for the same concept might lead to needless confusion.
+R recommends using the [ISI Multilingual Glossary of Statistical Terms](https://www.isi-web.org/publications/glossary-of-statistical-terms) to help overcome this issue.
 
 ## Trying out your work
 

--- a/vignettes/translators.Rmd
+++ b/vignettes/translators.Rmd
@@ -115,10 +115,6 @@ For example, you can add some Argentinian messages to `es_AR`; users running R i
 Chinese is a slightly different case -- typically, the `zh_CN` domain is used to write with simplified characters while `zh_TW` is used for traditional characters.
 In principal you could leverage `zh_TW` for Taiwanisms and `zh_HK` for Hongkieisms.
 
-Currently, translation is limited to the same set of domains as is available for base R: Danish, German, English, British English, Spanish, Farsi, French, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portugese, Russian, Turkish, Mainland Chinese, and Taiwanese Chinese.
-
-This list can be expanded; please file an Issue request on GitHub.
-
 ## Message variations
 
 The following sections describe four important message variations:


### PR DESCRIPTION
Most of the contents moved into the documentation for `translate_package()`, since there was already substantial overlap with the README. I've done some minor de-duplication, but more still needs to be done.

I also moved some content into the developer and translator vignettes, these will also need to be rewritten to improve the flow. I didn't want to do too much re-writing here since the story is going to continue to evolve as translate_package() becomes a more of a wrapper around `po_*()` functions. (i.e. the information about diasporic languages applies to both `po_create()` and `translate_package()` but we don't have a good place to put it currently).

Fixes #276